### PR TITLE
Fix typo in Displays example

### DIFF
--- a/examples/Display/Displays.ino
+++ b/examples/Display/Displays.ino
@@ -288,7 +288,7 @@ void selectline (int potnumb){
       lcd.print(actuatorValues[potnumb]);
     }
     else {
-      lcd2.print("[ - - 0 - - ] ");
+      lcd2.print("[ - - O - - ] ");
       lcd2.print(actuatorValues[potnumb]);
     }
   break;


### PR DESCRIPTION
I caught this typo when reading the [LiquidCrystal tutorial](https://wiki.moddevices.com/wiki/Arduino_LiquidCrystal_tutorial). One of the display bars has a zero (`0`) instead of a capital o (`O`). See "Pot 4" in the photo below:

![lcd-5](https://user-images.githubusercontent.com/1534870/49850802-c318c380-fd93-11e8-807c-9b0d88c3734e.png)
